### PR TITLE
Add GitHub Actions CI with DuckDB integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,27 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-duckdb:
+    name: Integration Tests (DuckDB)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dbt-duckdb
+        run: pip install dbt-duckdb
+
+      - name: Run integration tests
+        run: bash scripts/run_integration_tests_duckdb.sh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-          cache: pip
 
       - name: Install dbt-duckdb
         run: pip install dbt-duckdb

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -3,7 +3,8 @@ integration_tests_duckdb:
   outputs:
     dev:
       type: duckdb
-      path: "../duckdb/test_dbt_orphan.duckdb"
+      path: "../duckdb/integration_test.duckdb"
+      schema: test_dbt_orphan
 
 integration_tests_postgres:
   target: postgres

--- a/scripts/run_integration_tests_duckdb.sh
+++ b/scripts/run_integration_tests_duckdb.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INT_TESTS_DIR="$REPO_ROOT/integration_tests"
+
+echo "=== dbt-orphan Integration Tests (DuckDB) ==="
+echo ""
+
+mkdir -p "$REPO_ROOT/duckdb"
+
+cd "$INT_TESTS_DIR"
+
+echo "1. Installing dependencies..."
+dbt deps --profile integration_tests_duckdb
+
+echo ""
+echo "2. Running dbt models..."
+dbt run --profile integration_tests_duckdb
+
+echo ""
+echo "3. Creating orphan tables..."
+dbt run-operation create_orphan_tables --profile integration_tests_duckdb
+
+echo ""
+echo "4. Running cleanup_orphans (dry run)..."
+dbt run-operation dbt_orphan.cleanup_orphans \
+  --args '{schemas: ["test_dbt_orphan"], dry_run: true}' \
+  --profile integration_tests_duckdb
+
+echo ""
+echo "5. Running cleanup_orphans (actual cleanup)..."
+dbt run-operation dbt_orphan.cleanup_orphans \
+  --args '{schemas: ["test_dbt_orphan"], dry_run: false}' \
+  --profile integration_tests_duckdb
+
+echo ""
+echo "6. Running tests..."
+dbt test --profile integration_tests_duckdb
+
+echo ""
+echo "=== All tests passed! ==="


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/integration-tests.yml` that runs on every push/PR to `main`
- Adds `scripts/run_integration_tests_duckdb.sh` as a self-contained DuckDB test runner
- Fixes `integration_tests/profiles.yml` DuckDB path to avoid catalog/schema name collision (`test_dbt_orphan.duckdb` → `integration_test.duckdb`)

No external database required — DuckDB runs in-process, so CI works out of the box with just a `pip install dbt-duckdb`.

## Test plan
- [x] Verified locally: all 6 steps pass including dry run, actual cleanup, and both data tests
- [ ] Confirm GitHub Actions workflow triggers and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)