### PR TITLE
Add BigQuery adapter support for get_orphans and cleanup_orphans

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,14 @@ on-run-end:
 - **Always test with `dry_run: true` first** to preview what will be dropped
 - Only schemas explicitly listed will be scanned
 - Use `exclude_patterns` to protect tables that exist outside of dbt
+- **Run against the same target/environment as the schemas you are scanning.** The orphan comparison works by matching database objects against nodes in the dbt graph. If you invoke the macro with a `dev` target but point `schemas` at production datasets, every production table will appear orphaned because the graph nodes carry the dev database and schema names. Always ensure `target.database` and `target.schema` match the environment you intend to clean.
+
+## Adapter Notes
+
+### BigQuery
+
+Tested on a live dbt-BigQuery project (dbt 1.10.13, dbt-bigquery 1.10.2) with dry-run against several datasets.
+
+- Hyphenated project IDs (e.g. `xyz-dev`) are handled correctly via `adapter.quote(database)`, both in the `INFORMATION_SCHEMA` reference and in the backtick-qualified DROP targets.
+- `get_orphans` unions across all requested datasets in a single query; results are consistent with what `cleanup_orphans` flags per schema.
+- Because BigQuery's `INFORMATION_SCHEMA` is per-dataset, the macro issues one sub-query per schema and unions the results — this is expected behaviour and not a performance concern for typical schema counts.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A dbt package that automatically cleans up orphaned database objects (tables and
 - PostgreSQL
 - Snowflake
 - DuckDB
+- BigQuery
 
 ## Installation
 

--- a/macros/cleanup_orphans.sql
+++ b/macros/cleanup_orphans.sql
@@ -72,6 +72,56 @@
 {% endmacro %}
 
 
+{% macro bigquery__cleanup_orphans(database, schema, dry_run, exclude_patterns, dbt_objects) %}
+    {% set db_objects_query %}
+        select
+            table_name,
+            table_type
+        from {{ adapter.quote(database) }}.{{ schema }}.INFORMATION_SCHEMA.TABLES
+        where table_type in ('BASE TABLE', 'VIEW')
+            {% for pattern in exclude_patterns %}
+                and lower(table_name) not like lower('{{ pattern }}')
+            {% endfor %}
+        order by table_name
+    {% endset %}
+
+    {% set db_objects_result = run_query(db_objects_query) %}
+
+    {% set orphaned_count = [] %}
+    {% if db_objects_result %}
+        {% for row in db_objects_result %}
+            {% set obj_name = row['table_name'] | lower %}
+            {% if obj_name not in dbt_objects %}
+                {% set object_type = 'VIEW' if row['table_type'] == 'VIEW' else 'TABLE' %}
+                {# Backtick-qualify all parts since BigQuery project IDs can contain hyphens #}
+                {% set full_name = '`' ~ database ~ '`.' ~ '`' ~ schema ~ '`.' ~ '`' ~ row['table_name'] ~ '`' %}
+
+                {% if dry_run %}
+                    {{ log('[DRY RUN] Would drop ' ~ object_type ~ ' ' ~ full_name ~ ' (not in dbt graph)', info=true) }}
+                {% else %}
+                    {{ log('Dropping orphaned ' ~ object_type ~ ' ' ~ full_name ~ ' (not in dbt graph)', info=true) }}
+                    {% set drop_statement %}
+                        DROP {{ object_type }} IF EXISTS {{ full_name }}
+                    {% endset %}
+                    {% do run_query(drop_statement) %}
+                {% endif %}
+                {% do orphaned_count.append(1) %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+
+    {% if orphaned_count | length > 0 %}
+        {% if dry_run %}
+            {{ log('[DRY RUN] Found ' ~ orphaned_count | length ~ ' orphaned object(s) that would be dropped', info=true) }}
+        {% else %}
+            {{ log('Dropped ' ~ orphaned_count | length ~ ' orphaned object(s)', info=true) }}
+        {% endif %}
+    {% else %}
+        {{ log('No orphaned objects found in ' ~ database ~ '.' ~ schema, info=true) }}
+    {% endif %}
+{% endmacro %}
+
+
 {% macro snowflake__cleanup_orphans(database, schema, dry_run, exclude_patterns, dbt_objects) %}
     {% set db_objects_query %}
         select

--- a/macros/get_orphans.sql
+++ b/macros/get_orphans.sql
@@ -70,6 +70,73 @@
 {% endmacro %}
 
 
+{% macro bigquery__get_orphans(database, schemas, exclude_patterns) %}
+    {# Build set of object names managed by dbt across all specified schemas #}
+    {% set dbt_objects_by_schema = {} %}
+    {% for schema in schemas %}
+        {% do dbt_objects_by_schema.update({schema | lower: []}) %}
+    {% endfor %}
+
+    {% set nodes_dict = graph.get('nodes', graph) %}
+    {% for unique_id, node in nodes_dict.items() %}
+        {% if node.resource_type in ['model', 'seed', 'snapshot'] %}
+            {% set node_schema = node.schema | lower %}
+            {% if node_schema in dbt_objects_by_schema %}
+                {% if node.database | lower == database | lower or node.database is none %}
+                    {% do dbt_objects_by_schema[node_schema].append(node.name | lower) %}
+                {% endif %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
+    {# Build a CTE with all dbt-managed objects #}
+    with dbt_objects as (
+        {% set dbt_object_rows = [] %}
+        {% for schema, objects in dbt_objects_by_schema.items() %}
+            {% for obj in objects %}
+                {% do dbt_object_rows.append("select '" ~ schema ~ "' as schema_name, '" ~ obj ~ "' as object_name") %}
+            {% endfor %}
+        {% endfor %}
+        {% if dbt_object_rows | length > 0 %}
+            {{ dbt_object_rows | join(' union all ') }}
+        {% else %}
+            select null as schema_name, null as object_name where false
+        {% endif %}
+    ),
+
+    {# BigQuery INFORMATION_SCHEMA is per-dataset, so union all across each requested schema #}
+    db_objects as (
+        {% for schema in schemas %}
+        select
+            lower(table_schema) as schema_name,
+            lower(table_name) as object_name,
+            table_name as original_table_name,
+            table_schema as original_schema_name,
+            table_type
+        from {{ adapter.quote(database) }}.{{ schema }}.INFORMATION_SCHEMA.TABLES
+        where table_type in ('BASE TABLE', 'VIEW')
+        {% for pattern in exclude_patterns %}
+            and lower(table_name) not like lower('{{ pattern }}')
+        {% endfor %}
+        {% if not loop.last %}union all{% endif %}
+        {% endfor %}
+    )
+
+    select
+        '{{ database }}' as database_name,
+        db.original_schema_name as schema_name,
+        db.original_table_name as table_name,
+        db.table_type,
+        '{{ database }}' || '.' || db.original_schema_name || '.' || db.original_table_name as full_name
+    from db_objects db
+    left join dbt_objects dbt
+        on db.schema_name = dbt.schema_name
+        and db.object_name = dbt.object_name
+    where dbt.object_name is null
+    order by db.schema_name, db.original_table_name
+{% endmacro %}
+
+
 {% macro snowflake__get_orphans(database, schemas, exclude_patterns) %}
     {# Build set of object names managed by dbt across all specified schemas #}
     {% set dbt_objects_by_schema = {} %}


### PR DESCRIPTION
## Description & motivation

Adds `bigquery__get_orphans` and `bigquery__cleanup_orphans` dispatch implementations to resolve issue #3. BigQuery does not support unqualified `INFORMATION_SCHEMA.TABLES` — it requires per-dataset qualification (`project.dataset.INFORMATION_SCHEMA.TABLES`). The new macros union across each requested dataset for `get_orphans`, use `adapter.quote(database)` to handle project IDs with hyphens, and emit fully backtick-qualified DROP targets (e.g. `` `project`.`dataset`.`table` ``).

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)