### PR TITLE
Document include_patterns parameter in schema.yml and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Use the `get_orphans` macro to create a model that lists all orphaned objects wi
 -- models/orphaned_objects.sql
 {{ dbt_orphan.get_orphans(
     schemas=['analytics', 'staging', 'marts'],
-    exclude_patterns=['%_backup', 'temp_%']
+    exclude_patterns=['%_backup', 'temp_%'],
+    include_patterns=['stg_%', 'int_%']
 ) }}
 ```
 
@@ -95,6 +96,7 @@ dbt run-operation dbt_orphan.cleanup_orphans --args '{schemas: ["analytics", "st
 | `schemas` | list | `[target.schema]` | List of schemas to scan for orphans |
 | `dry_run` | boolean | `true` | When true, only logs what would be dropped |
 | `exclude_patterns` | list | `[]` | SQL LIKE patterns for table names to exclude |
+| `include_patterns` | list | `[]` | SQL LIKE patterns — only matching table names are considered (applied after exclude_patterns) |
 
 ## Example with Exclude Patterns
 
@@ -103,11 +105,21 @@ on-run-end:
   - "{{ dbt_orphan.cleanup_orphans(schemas=['analytics'], dry_run=false, exclude_patterns=['%_backup', 'tmp_%']) }}"
 ```
 
+## Example with Include Patterns
+
+Use `include_patterns` to limit cleanup or inspection to only objects whose names match a pattern. This is useful when you want to target a specific naming convention without listing every schema object explicitly.
+
+```yaml
+on-run-end:
+  - "{{ dbt_orphan.cleanup_orphans(schemas=['analytics'], dry_run=false, include_patterns=['stg_%', 'int_%']) }}"
+```
+
 ## Safety
 
 - **Always test with `dry_run: true` first** to preview what will be dropped
 - Only schemas explicitly listed will be scanned
 - Use `exclude_patterns` to protect tables that exist outside of dbt
+- Use `include_patterns` to restrict cleanup to only objects matching specific naming patterns
 - **Run against the same target/environment as the schemas you are scanning.** The orphan comparison works by matching database objects against nodes in the dbt graph. If you invoke the macro with a `dev` target but point `schemas` at production datasets, every production table will appear orphaned because the graph nodes carry the dev database and schema names. Always ensure `target.database` and `target.schema` match the environment you intend to clean.
 
 ## Adapter Notes

--- a/integration_tests/macros/create_include_pattern_test_tables.sql
+++ b/integration_tests/macros/create_include_pattern_test_tables.sql
@@ -1,0 +1,29 @@
+{% macro create_include_pattern_test_tables() %}
+    {#
+        Creates two tables to test include_patterns filtering:
+        - incl_orphan_for_testing  (matches include pattern "incl_%", should be dropped)
+        - noincl_orphan_for_testing (does NOT match, should be kept)
+    #}
+
+    {{ log('Creating include_pattern test tables...', info=true) }}
+
+    {% set incl_sql %}
+        create table if not exists test_dbt_orphan.incl_orphan_for_testing (
+            id integer
+        )
+    {% endset %}
+
+    {% set noincl_sql %}
+        create table if not exists test_dbt_orphan.noincl_orphan_for_testing (
+            id integer
+        )
+    {% endset %}
+
+    {% do run_query(incl_sql) %}
+    {{ log('Created incl_orphan_for_testing', info=true) }}
+
+    {% do run_query(noincl_sql) %}
+    {{ log('Created noincl_orphan_for_testing', info=true) }}
+
+    {{ log('Include pattern test tables created successfully', info=true) }}
+{% endmacro %}

--- a/integration_tests/run_tests.sh
+++ b/integration_tests/run_tests.sh
@@ -24,8 +24,20 @@ echo "5. Running cleanup_orphans (actual cleanup)..."
 dbt run-operation dbt_orphan.cleanup_orphans --args '{schemas: ["test_dbt_orphan"], dry_run: false}'
 
 echo ""
-echo "6. Running tests to verify results..."
+echo "6. Creating include_pattern test tables..."
+dbt run-operation create_include_pattern_test_tables
+
+echo ""
+echo "7. Running cleanup_orphans with include_patterns (should only drop incl_orphan_for_testing)..."
+dbt run-operation dbt_orphan.cleanup_orphans --args '{schemas: ["test_dbt_orphan"], dry_run: false, include_patterns: ["incl_%"]}'
+
+echo ""
+echo "8. Running tests to verify results..."
 dbt test
+
+echo ""
+echo "9. Final cleanup of remaining test artifacts..."
+dbt run-operation dbt_orphan.cleanup_orphans --args '{schemas: ["test_dbt_orphan"], dry_run: false}'
 
 echo ""
 echo "=== All tests passed! ==="

--- a/integration_tests/tests/test_include_pattern_drops_matching.sql
+++ b/integration_tests/tests/test_include_pattern_drops_matching.sql
@@ -1,0 +1,7 @@
+-- PASSES if incl_orphan_for_testing was dropped by cleanup_orphans with include_patterns=['incl_%']
+-- Returns rows (FAILS) if the table still exists
+
+select table_name
+from information_schema.tables
+where lower(table_schema) = lower('{{ target.schema }}')
+    and lower(table_name) = 'incl_orphan_for_testing'

--- a/integration_tests/tests/test_include_pattern_keeps_nonmatching.sql
+++ b/integration_tests/tests/test_include_pattern_keeps_nonmatching.sql
@@ -1,0 +1,10 @@
+-- PASSES if noincl_orphan_for_testing was NOT dropped by cleanup_orphans with include_patterns=['incl_%']
+-- Returns rows (FAILS) if the table is missing (was incorrectly dropped)
+
+select 'noincl_orphan_for_testing' as should_still_exist
+where not exists (
+    select 1
+    from information_schema.tables
+    where lower(table_schema) = lower('{{ target.schema }}')
+        and lower(table_name) = 'noincl_orphan_for_testing'
+)

--- a/macros/schema.yml
+++ b/macros/schema.yml
@@ -25,6 +25,12 @@ macros:
         description: >
           List of SQL LIKE patterns for table names to exclude from cleanup.
           Example: ["%_backup", "temp_%"]
+      - name: include_patterns
+        type: list
+        description: >
+          List of SQL LIKE patterns for table names to include in cleanup.
+          When non-empty, only objects whose names match at least one pattern are considered.
+          Applied after exclude_patterns. Example: ["stg_%", "%_v2"]
 
   - name: get_orphans
     description: >
@@ -45,3 +51,9 @@ macros:
         description: >
           List of SQL LIKE patterns for table names to exclude from results.
           Example: ["%_backup", "temp_%"]
+      - name: include_patterns
+        type: list
+        description: >
+          List of SQL LIKE patterns for table names to include in results.
+          When non-empty, only objects whose names match at least one pattern are considered.
+          Applied after exclude_patterns. Example: ["stg_%", "%_v2"]

--- a/scripts/run_integration_tests_duckdb.sh
+++ b/scripts/run_integration_tests_duckdb.sh
@@ -36,8 +36,24 @@ dbt run-operation dbt_orphan.cleanup_orphans \
   --profile integration_tests_duckdb
 
 echo ""
-echo "6. Running tests..."
+echo "6. Creating include_pattern test tables..."
+dbt run-operation create_include_pattern_test_tables --profile integration_tests_duckdb
+
+echo ""
+echo "7. Running cleanup_orphans with include_patterns (should only drop incl_orphan_for_testing)..."
+dbt run-operation dbt_orphan.cleanup_orphans \
+  --args '{schemas: ["test_dbt_orphan"], dry_run: false, include_patterns: ["incl_%"]}' \
+  --profile integration_tests_duckdb
+
+echo ""
+echo "8. Running tests..."
 dbt test --profile integration_tests_duckdb
+
+echo ""
+echo "9. Final cleanup of remaining test artifacts..."
+dbt run-operation dbt_orphan.cleanup_orphans \
+  --args '{schemas: ["test_dbt_orphan"], dry_run: false}' \
+  --profile integration_tests_duckdb
 
 echo ""
 echo "=== All tests passed! ==="


### PR DESCRIPTION
## Description & motivation

Adds documentation for the `include_patterns` parameter to `macros/schema.yml` and `README.md`. This parameter was implemented in PR #5 but was not reflected in any docs. The schema YAML now includes argument entries for both `cleanup_orphans` and `get_orphans`, and the README gains a parameter table row, an example section, and a safety bullet.

## Checklist
- [ ] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)